### PR TITLE
Prototype the next step of parser.rs refactoring towards moving more of parser.rs logic to shared.rs

### DIFF
--- a/nanvm-lib/src/parser/parser.rs
+++ b/nanvm-lib/src/parser/parser.rs
@@ -4,30 +4,14 @@ use super::shared::{
 };
 use super::{
     path::{concat, split},
-    shared::JsonElement,
+    shared::{JsonElement, ModuleCache},
 };
 use crate::{
     common::default::default,
-    js::any::Any,
-    mem::manager::{Dealloc, Manager},
+    mem::manager::Manager,
     tokenizer::{tokenize, JsonToken},
 };
 use io_trait::Io;
-use std::collections::{BTreeMap, BTreeSet};
-
-pub struct ModuleCache<D: Dealloc> {
-    pub complete: BTreeMap<String, Any<D>>,
-    pub progress: BTreeSet<String>,
-}
-
-impl<D: Dealloc> Default for ModuleCache<D> {
-    fn default() -> Self {
-        Self {
-            complete: default(),
-            progress: default(),
-        }
-    }
-}
 
 pub struct Context<'a, M: Manager, I: Io> {
     manager: M,

--- a/nanvm-lib/src/parser/parser.rs
+++ b/nanvm-lib/src/parser/parser.rs
@@ -1,6 +1,6 @@
 use super::shared::{
-    AnyResult, AnyState, AnyStateExtension, ConstState, JsonState, ParseError, ParseResult,
-    ParsingStatus, RootState, RootStatus,
+    AnyResult, AnyState, ConstState, JsonState, ParseError, ParseResult, ParsingStatus, RootState,
+    RootStatus,
 };
 use super::{
     path::{concat, split},
@@ -37,10 +37,10 @@ impl<'a, M: Manager, I: Io> Context<'a, M, I> {
 }
 
 fn root_state_parse<M: Manager, I: Io>(
-    mut root_state: RootState<M::Dealloc>,
+    mut root_state: RootState<M>,
     context: &mut Context<M, I>,
     token: JsonToken,
-) -> JsonState<M::Dealloc> {
+) -> JsonState<M> {
     match root_state.status {
         RootStatus::Initial => match token {
             JsonToken::NewLine => JsonState::ParseRoot(RootState {
@@ -195,10 +195,10 @@ fn root_state_parse<M: Manager, I: Io>(
 }
 
 fn const_state_parse<M: Manager, I: Io>(
-    const_state: ConstState<M::Dealloc>,
+    const_state: ConstState<M>,
     context: &mut Context<M, I>,
     token: JsonToken,
-) -> JsonState<M::Dealloc> {
+) -> JsonState<M> {
     match token {
         JsonToken::Semicolon => todo!(),
         _ => {
@@ -223,10 +223,10 @@ fn const_state_parse<M: Manager, I: Io>(
 }
 
 fn any_state_parse_for_module<M: Manager, I: Io>(
-    any_state: AnyState<M::Dealloc>,
+    any_state: AnyState<M>,
     context: &mut Context<M, I>,
     token: JsonToken,
-) -> JsonState<M::Dealloc> {
+) -> JsonState<M> {
     let result = any_state_parse(any_state, context, token);
     match result {
         AnyResult::Continue(state) => JsonState::ParseModule(state),
@@ -239,10 +239,10 @@ fn any_state_parse_for_module<M: Manager, I: Io>(
 }
 
 fn any_state_parse_import_value<M: Manager, I: Io>(
-    any_state: AnyState<M::Dealloc>,
+    any_state: AnyState<M>,
     context: &mut Context<M, I>,
     token: JsonToken,
-) -> AnyResult<M::Dealloc> {
+) -> AnyResult<M> {
     match token {
         JsonToken::String(s) => {
             let current_path = concat(split(&context.path).0, s.as_str());
@@ -278,7 +278,7 @@ fn any_state_parse_import_value<M: Manager, I: Io>(
                         Err(e) => AnyResult::Error(e),
                     }
                 }
-                Err(_) => AnyResult::<M::Dealloc>::Error(ParseError::CannotReadFile),
+                Err(_) => AnyResult::<M>::Error(ParseError::CannotReadFile),
             }
         }
         _ => AnyResult::Error(ParseError::WrongRequireStatement),
@@ -286,10 +286,10 @@ fn any_state_parse_import_value<M: Manager, I: Io>(
 }
 
 fn any_state_parse<M: Manager, I: Io>(
-    any_state: AnyState<M::Dealloc>,
+    any_state: AnyState<M>,
     context: &mut Context<M, I>,
     token: JsonToken,
-) -> AnyResult<M::Dealloc> {
+) -> AnyResult<M> {
     match any_state.status {
         ParsingStatus::Initial | ParsingStatus::ObjectColon => {
             any_state.parse_value(context.manager, token)
@@ -308,10 +308,10 @@ fn any_state_parse<M: Manager, I: Io>(
 }
 
 fn json_state_push<M: Manager, I: Io>(
-    json_state: JsonState<M::Dealloc>,
+    json_state: JsonState<M>,
     context: &mut Context<M, I>,
     token: JsonToken,
-) -> JsonState<M::Dealloc> {
+) -> JsonState<M> {
     if token == JsonToken::NewLine {
         return match json_state {
             JsonState::ParseRoot(state) => root_state_parse(state, context, token),

--- a/nanvm-lib/src/parser/shared.rs
+++ b/nanvm-lib/src/parser/shared.rs
@@ -1,3 +1,4 @@
+use super::path::{concat, split};
 use crate::{
     common::{cast::Cast, default::default},
     js::{
@@ -10,7 +11,7 @@ use crate::{
     mem::manager::{Dealloc, Manager},
     tokenizer::JsonToken,
 };
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Display;
 
 #[derive(Debug, Default, PartialEq)]
@@ -90,6 +91,20 @@ impl Display for ParseError {
     }
 }
 
+pub struct ModuleCache<D: Dealloc> {
+    pub complete: BTreeMap<String, Any<D>>,
+    pub progress: BTreeSet<String>,
+}
+
+impl<D: Dealloc> Default for ModuleCache<D> {
+    fn default() -> Self {
+        Self {
+            complete: default(),
+            progress: default(),
+        }
+    }
+}
+
 pub enum JsonStackElement<D: Dealloc> {
     Object(JsonStackObject<D>),
     Array(Vec<Any<D>>),
@@ -137,10 +152,206 @@ pub struct ParseResult<D: Dealloc> {
     pub any: Any<D>,
 }
 
+pub struct RootStateParseResult<D: Dealloc> {
+    pub json_state: JsonState<D>,
+    pub import_from_path: Option<String>, // an extra output in case of "import from" statement
+}
+
+impl<D: Dealloc> RootStateParseResult<D> {
+    pub fn new(json_state: JsonState<D>) -> RootStateParseResult<D> {
+        RootStateParseResult {
+            json_state,
+            import_from_path: None,
+        }
+    }
+
+    pub fn new_error(error: ParseError) -> RootStateParseResult<D> {
+        RootStateParseResult {
+            json_state: JsonState::Error(error),
+            import_from_path: None,
+        }
+    }
+
+    pub fn new_with_import_from(
+        json_state: JsonState<D>,
+        import_from_path: String,
+    ) -> RootStateParseResult<D> {
+        RootStateParseResult {
+            json_state,
+            import_from_path: Some(import_from_path),
+        }
+    }
+}
+
 pub struct RootState<D: Dealloc> {
     pub status: RootStatus,
     pub state: AnyState<D>,
     pub new_line: bool,
+}
+
+/// AnyStateExtension contains RootState methods that use Manager (not only Dealloc).
+pub trait RootStateExtension<M: Manager> {
+    fn parse(
+        self,
+        manager: M,
+        token: JsonToken,
+        module_cache: &mut ModuleCache<M::Dealloc>,
+        context_path: String,
+    ) -> RootStateParseResult<M::Dealloc>;
+}
+
+impl<M: Manager> RootStateExtension<M> for RootState<M::Dealloc> {
+    fn parse(
+        self,
+        manager: M,
+        token: JsonToken,
+        module_cache: &mut ModuleCache<M::Dealloc>,
+        context_path: String,
+    ) -> RootStateParseResult<M::Dealloc> {
+        match self.status {
+            RootStatus::Initial => match token {
+                JsonToken::NewLine => RootStateParseResult::new(JsonState::ParseRoot(RootState {
+                    new_line: true,
+                    ..self
+                })),
+                JsonToken::Id(s) => match self.new_line {
+                    true => match s.as_ref() {
+                        "const" => RootStateParseResult::new(JsonState::ParseRoot(RootState {
+                            status: RootStatus::Const,
+                            state: self.state.set_djs(),
+                            new_line: false,
+                        })),
+                        "export" if self.state.data_type.is_mjs_compatible() => {
+                            RootStateParseResult::new(JsonState::ParseRoot(RootState {
+                                status: RootStatus::Export,
+                                state: self.state.set_mjs(),
+                                new_line: false,
+                            }))
+                        }
+                        "module" if self.state.data_type.is_cjs_compatible() => {
+                            RootStateParseResult::new(JsonState::ParseRoot(RootState {
+                                status: RootStatus::Module,
+                                state: self.state.set_cjs(),
+                                new_line: false,
+                            }))
+                        }
+                        "import" if self.state.data_type.is_mjs_compatible() => {
+                            RootStateParseResult::new(JsonState::ParseRoot(RootState {
+                                status: RootStatus::Import,
+                                state: self.state.set_mjs(),
+                                new_line: false,
+                            }))
+                        }
+                        _ => RootStateParseResult::new(self.state.parse_for_module(
+                            manager,
+                            JsonToken::Id(s),
+                            &mut module_cache.progress,
+                        )),
+                    },
+                    false => RootStateParseResult::new_error(ParseError::NewLineExpected),
+                },
+                _ => match self.new_line {
+                    true => RootStateParseResult::new(self.state.parse_for_module(
+                        manager,
+                        token,
+                        &mut module_cache.progress,
+                    )),
+                    false => RootStateParseResult::new_error(ParseError::NewLineExpected),
+                },
+            },
+            RootStatus::Export => match token {
+                JsonToken::Id(s) => match s.as_ref() {
+                    "default" => RootStateParseResult::new(JsonState::ParseModule(self.state)),
+                    _ => RootStateParseResult::new_error(ParseError::WrongExportStatement),
+                },
+                _ => RootStateParseResult::new_error(ParseError::WrongExportStatement),
+            },
+            RootStatus::Module => match token {
+                JsonToken::Dot => RootStateParseResult::new(JsonState::ParseRoot(RootState {
+                    status: RootStatus::ModuleDot,
+                    state: self.state,
+                    new_line: false,
+                })),
+                _ => RootStateParseResult::new_error(ParseError::WrongExportStatement),
+            },
+            RootStatus::ModuleDot => match token {
+                JsonToken::Id(s) => match s.as_ref() {
+                    "exports" => RootStateParseResult::new(JsonState::ParseRoot(RootState {
+                        status: RootStatus::ModuleDotExports,
+                        state: self.state,
+                        new_line: false,
+                    })),
+                    _ => RootStateParseResult::new_error(ParseError::WrongExportStatement),
+                },
+                _ => RootStateParseResult::new_error(ParseError::WrongExportStatement),
+            },
+            RootStatus::ModuleDotExports => match token {
+                JsonToken::Equals => RootStateParseResult::new(JsonState::ParseModule(self.state)),
+                _ => RootStateParseResult::new_error(ParseError::WrongExportStatement),
+            },
+            RootStatus::Const => match token {
+                JsonToken::Id(s) => RootStateParseResult::new(JsonState::ParseRoot(RootState {
+                    status: RootStatus::ConstId(s),
+                    state: self.state,
+                    new_line: false,
+                })),
+                _ => RootStateParseResult::new_error(ParseError::WrongConstStatement),
+            },
+            RootStatus::ConstId(s) => match token {
+                JsonToken::Equals => RootStateParseResult::new(JsonState::ParseConst(ConstState {
+                    key: s,
+                    state: self.state,
+                })),
+                _ => RootStateParseResult::new_error(ParseError::WrongConstStatement),
+            },
+            RootStatus::Import => match token {
+                JsonToken::Id(s) => RootStateParseResult::new(JsonState::ParseRoot(RootState {
+                    status: RootStatus::ImportId(s),
+                    state: self.state,
+                    new_line: false,
+                })),
+                _ => RootStateParseResult::new_error(ParseError::WrongImportStatement),
+            },
+            RootStatus::ImportId(id) => match token {
+                JsonToken::Id(s) => match s.as_ref() {
+                    "from" => RootStateParseResult::new(JsonState::ParseRoot(RootState {
+                        status: RootStatus::ImportIdFrom(id),
+                        state: self.state,
+                        new_line: false,
+                    })),
+                    _ => RootStateParseResult::new_error(ParseError::WrongImportStatement),
+                },
+                _ => RootStateParseResult::new_error(ParseError::WrongImportStatement),
+            },
+            RootStatus::ImportIdFrom(id) => match token {
+                JsonToken::String(s) => {
+                    let import_from_path = concat(split(&context_path).0, s.as_str());
+                    if let Some(any) = module_cache.complete.get(&import_from_path) {
+                        let mut state = self.state;
+                        state.consts.insert(id, any.clone());
+                        return RootStateParseResult::new(JsonState::ParseRoot(RootState {
+                            status: RootStatus::Initial,
+                            state,
+                            new_line: false,
+                        }));
+                    }
+                    if module_cache.progress.contains(&import_from_path) {
+                        return RootStateParseResult::new_error(ParseError::CircularDependency);
+                    }
+                    module_cache.progress.insert(import_from_path.clone());
+                    RootStateParseResult::new_with_import_from(
+                        JsonState::ParseRoot(RootState {
+                            status: RootStatus::Initial,
+                            new_line: false,
+                            ..self
+                        }),
+                        import_from_path,
+                    )
+                }
+                _ => RootStateParseResult::new_error(ParseError::WrongImportStatement),
+            },
+        }
+    }
 }
 
 pub struct ConstState<D: Dealloc> {
@@ -350,6 +561,13 @@ impl<D: Dealloc> AnyState<D> {
 pub trait AnyStateExtension<M: Manager> {
     fn end_array(self, manager: M) -> AnyResult<M::Dealloc>;
     fn end_object(self, manager: M) -> AnyResult<M::Dealloc>;
+    fn parse(self, manager: M, token: JsonToken) -> AnyResult<M::Dealloc>;
+    fn parse_for_module(
+        self,
+        manager: M,
+        token: JsonToken,
+        _module_cache_progress: &mut BTreeSet<String>,
+    ) -> JsonState<M::Dealloc>;
     fn parse_value(self, manager: M, token: JsonToken) -> AnyResult<M::Dealloc>;
     fn parse_array_comma(self, manager: M, token: JsonToken) -> AnyResult<M::Dealloc>;
     fn parse_array_begin(self, manager: M, token: JsonToken) -> AnyResult<M::Dealloc>;
@@ -392,6 +610,39 @@ impl<M: Manager> AnyStateExtension<M> for AnyState<M::Dealloc> {
                 new_state.push_value(Any::move_from(js_object))
             }
             _ => unreachable!(),
+        }
+    }
+
+    fn parse(self, manager: M, token: JsonToken) -> AnyResult<M::Dealloc> {
+        match self.status {
+            ParsingStatus::Initial | ParsingStatus::ObjectColon => self.parse_value(manager, token),
+            ParsingStatus::ArrayBegin => self.parse_array_begin(manager, token),
+            ParsingStatus::ArrayValue => self.parse_array_value(manager, token),
+            ParsingStatus::ArrayComma => self.parse_array_comma(manager, token),
+            ParsingStatus::ObjectBegin => self.parse_object_begin(manager, token),
+            ParsingStatus::ObjectKey => self.parse_object_key(token),
+            ParsingStatus::ObjectValue => self.parse_object_next(manager, token),
+            ParsingStatus::ObjectComma => self.parse_object_comma(manager, token),
+            ParsingStatus::ImportBegin => self.parse_import_begin(token),
+            ParsingStatus::ImportValue => todo!(), // any_state, context, token),
+            ParsingStatus::ImportEnd => self.parse_import_end(token),
+        }
+    }
+
+    fn parse_for_module(
+        self,
+        manager: M,
+        token: JsonToken,
+        _module_cache_progress: &mut BTreeSet<String>,
+    ) -> JsonState<M::Dealloc> {
+        let result = self.parse(manager, token);
+        match result {
+            AnyResult::Continue(state) => JsonState::ParseModule(state),
+            AnyResult::Success(success) => JsonState::Result(ParseResult {
+                data_type: success.state.data_type,
+                any: success.value,
+            }),
+            AnyResult::Error(error) => JsonState::Error(error),
         }
     }
 

--- a/nanvm-lib/src/parser/shared.rs
+++ b/nanvm-lib/src/parser/shared.rs
@@ -121,14 +121,14 @@ pub enum JsonElement<D: Dealloc> {
     Any(Any<D>),
 }
 
-pub struct AnySuccess<D: Dealloc> {
-    pub state: AnyState<D>,
-    pub value: Any<D>,
+pub struct AnySuccess<M: Manager> {
+    pub state: AnyState<M>,
+    pub value: Any<M::Dealloc>,
 }
 
-pub enum AnyResult<D: Dealloc> {
-    Continue(AnyState<D>),
-    Success(AnySuccess<D>),
+pub enum AnyResult<M: Manager> {
+    Continue(AnyState<M>),
+    Success(AnySuccess<M>),
     Error(ParseError),
 }
 
@@ -152,30 +152,27 @@ pub struct ParseResult<D: Dealloc> {
     pub any: Any<D>,
 }
 
-pub struct RootStateParseResult<D: Dealloc> {
-    pub json_state: JsonState<D>,
+pub struct RootStateParseResult<M: Manager> {
+    pub json_state: JsonState<M>,
     pub import_from_path: Option<String>, // an extra output in case of "import from" statement
 }
 
-impl<D: Dealloc> RootStateParseResult<D> {
-    pub fn new(json_state: JsonState<D>) -> RootStateParseResult<D> {
+impl<M: Manager> RootStateParseResult<M> {
+    pub fn new(json_state: JsonState<M>) -> Self {
         RootStateParseResult {
             json_state,
             import_from_path: None,
         }
     }
 
-    pub fn new_error(error: ParseError) -> RootStateParseResult<D> {
+    pub fn new_error(error: ParseError) -> Self {
         RootStateParseResult {
             json_state: JsonState::Error(error),
             import_from_path: None,
         }
     }
 
-    pub fn new_with_import_from(
-        json_state: JsonState<D>,
-        import_from_path: String,
-    ) -> RootStateParseResult<D> {
+    pub fn new_with_import_from(json_state: JsonState<M>, import_from_path: String) -> Self {
         RootStateParseResult {
             json_state,
             import_from_path: Some(import_from_path),
@@ -183,31 +180,20 @@ impl<D: Dealloc> RootStateParseResult<D> {
     }
 }
 
-pub struct RootState<D: Dealloc> {
+pub struct RootState<M: Manager> {
     pub status: RootStatus,
-    pub state: AnyState<D>,
+    pub state: AnyState<M>,
     pub new_line: bool,
 }
 
-/// AnyStateExtension contains RootState methods that use Manager (not only Dealloc).
-pub trait RootStateExtension<M: Manager> {
+impl<M: Manager> RootState<M> {
     fn parse(
         self,
         manager: M,
         token: JsonToken,
         module_cache: &mut ModuleCache<M::Dealloc>,
         context_path: String,
-    ) -> RootStateParseResult<M::Dealloc>;
-}
-
-impl<M: Manager> RootStateExtension<M> for RootState<M::Dealloc> {
-    fn parse(
-        self,
-        manager: M,
-        token: JsonToken,
-        module_cache: &mut ModuleCache<M::Dealloc>,
-        context_path: String,
-    ) -> RootStateParseResult<M::Dealloc> {
+    ) -> RootStateParseResult<M> {
         match self.status {
             RootStatus::Initial => match token {
                 JsonToken::NewLine => RootStateParseResult::new(JsonState::ParseRoot(RootState {
@@ -354,21 +340,21 @@ impl<M: Manager> RootStateExtension<M> for RootState<M::Dealloc> {
     }
 }
 
-pub struct ConstState<D: Dealloc> {
+pub struct ConstState<M: Manager> {
     pub key: String,
-    pub state: AnyState<D>,
+    pub state: AnyState<M>,
 }
 
-pub enum JsonState<D: Dealloc> {
-    ParseRoot(RootState<D>),
-    ParseConst(ConstState<D>),
-    ParseModule(AnyState<D>),
-    Result(ParseResult<D>),
+pub enum JsonState<M: Manager> {
+    ParseRoot(RootState<M>),
+    ParseConst(ConstState<M>),
+    ParseModule(AnyState<M>),
+    Result(ParseResult<M::Dealloc>),
     Error(ParseError),
 }
 
-impl<D: Dealloc> JsonState<D> {
-    pub fn end(self) -> Result<ParseResult<D>, ParseError> {
+impl<M: Manager> JsonState<M> {
+    pub fn end(self) -> Result<ParseResult<M::Dealloc>, ParseError> {
         match self {
             JsonState::Result(result) => Ok(result),
             JsonState::Error(error) => Err(error),
@@ -377,15 +363,15 @@ impl<D: Dealloc> JsonState<D> {
     }
 }
 
-pub struct AnyState<D: Dealloc> {
+pub struct AnyState<M: Manager> {
     pub data_type: DataType,
     pub status: ParsingStatus,
-    pub current: JsonElement<D>,
-    pub stack: Vec<JsonStackElement<D>>,
-    pub consts: BTreeMap<String, Any<D>>,
+    pub current: JsonElement<M::Dealloc>,
+    pub stack: Vec<JsonStackElement<M::Dealloc>>,
+    pub consts: BTreeMap<String, Any<M::Dealloc>>,
 }
 
-impl<D: Dealloc> Default for AnyState<D> {
+impl<M: Manager> Default for AnyState<M> {
     fn default() -> Self {
         AnyState {
             data_type: default(),
@@ -398,7 +384,7 @@ impl<D: Dealloc> Default for AnyState<D> {
 }
 
 // AnyState methods that use Dealloc only - methods that use Manager are in AnyStateExtension.
-impl<D: Dealloc> AnyState<D> {
+impl<M: Manager> AnyState<M> {
     pub fn set_djs(self) -> Self {
         AnyState {
             data_type: DataType::Djs,
@@ -420,7 +406,40 @@ impl<D: Dealloc> AnyState<D> {
         }
     }
 
-    pub fn parse_import_begin(self, token: JsonToken) -> AnyResult<D> {
+    pub fn parse(self, manager: M, token: JsonToken) -> AnyResult<M> {
+        match self.status {
+            ParsingStatus::Initial | ParsingStatus::ObjectColon => self.parse_value(manager, token),
+            ParsingStatus::ArrayBegin => self.parse_array_begin(manager, token),
+            ParsingStatus::ArrayValue => self.parse_array_value(manager, token),
+            ParsingStatus::ArrayComma => self.parse_array_comma(manager, token),
+            ParsingStatus::ObjectBegin => self.parse_object_begin(manager, token),
+            ParsingStatus::ObjectKey => self.parse_object_key(token),
+            ParsingStatus::ObjectValue => self.parse_object_next(manager, token),
+            ParsingStatus::ObjectComma => self.parse_object_comma(manager, token),
+            ParsingStatus::ImportBegin => self.parse_import_begin(token),
+            ParsingStatus::ImportValue => todo!(), // any_state, context, token),
+            ParsingStatus::ImportEnd => self.parse_import_end(token),
+        }
+    }
+
+    pub fn parse_for_module(
+        self,
+        manager: M,
+        token: JsonToken,
+        _module_cache_progress: &mut BTreeSet<String>,
+    ) -> JsonState<M> {
+        let result = self.parse(manager, token);
+        match result {
+            AnyResult::Continue(state) => JsonState::ParseModule(state),
+            AnyResult::Success(success) => JsonState::Result(ParseResult {
+                data_type: success.state.data_type,
+                any: success.value,
+            }),
+            AnyResult::Error(error) => JsonState::Error(error),
+        }
+    }
+
+    pub fn parse_import_begin(self, token: JsonToken) -> AnyResult<M> {
         match token {
             JsonToken::OpeningParenthesis => AnyResult::Continue(AnyState {
                 status: ParsingStatus::ImportValue,
@@ -430,14 +449,26 @@ impl<D: Dealloc> AnyState<D> {
         }
     }
 
-    pub fn parse_import_end(self, token: JsonToken) -> AnyResult<D> {
+    pub fn parse_import_end(self, token: JsonToken) -> AnyResult<M> {
         match token {
             JsonToken::ClosingParenthesis => self.end_import(),
             _ => AnyResult::Error(ParseError::WrongRequireStatement),
         }
     }
 
-    pub fn end_import(mut self) -> AnyResult<D> {
+    pub fn begin_import(mut self) -> AnyResult<M> {
+        if let JsonElement::Stack(top) = self.current {
+            self.stack.push(top);
+        }
+        AnyResult::Continue(AnyState {
+            data_type: DataType::Cjs,
+            status: ParsingStatus::ImportBegin,
+            current: JsonElement::None,
+            ..self
+        })
+    }
+
+    pub fn end_import(mut self) -> AnyResult<M> {
         match self.current {
             JsonElement::Any(any) => {
                 let current = match self.stack.pop() {
@@ -455,7 +486,24 @@ impl<D: Dealloc> AnyState<D> {
         }
     }
 
-    pub fn push_value(self, value: Any<D>) -> AnyResult<D> {
+    pub fn parse_value(self, manager: M, token: JsonToken) -> AnyResult<M> {
+        match token {
+            JsonToken::ArrayBegin => self.begin_array(),
+            JsonToken::ObjectBegin => self.begin_object(),
+            JsonToken::Id(s) if self.data_type.is_cjs_compatible() && s == "require" => {
+                self.begin_import()
+            }
+            _ => {
+                let option_any = token.try_to_any(manager, &self.consts);
+                match option_any {
+                    Some(any) => self.push_value(any),
+                    None => AnyResult::Error(ParseError::UnexpectedToken),
+                }
+            }
+        }
+    }
+
+    pub fn push_value(self, value: Any<M::Dealloc>) -> AnyResult<M> {
         match self.current {
             JsonElement::None => AnyResult::Success(AnySuccess {
                 state: AnyState {
@@ -490,19 +538,7 @@ impl<D: Dealloc> AnyState<D> {
         }
     }
 
-    pub fn begin_import(mut self) -> AnyResult<D> {
-        if let JsonElement::Stack(top) = self.current {
-            self.stack.push(top);
-        }
-        AnyResult::Continue(AnyState {
-            data_type: DataType::Cjs,
-            status: ParsingStatus::ImportBegin,
-            current: JsonElement::None,
-            ..self
-        })
-    }
-
-    pub fn push_key(self, s: String) -> AnyResult<D> {
+    pub fn push_key(self, s: String) -> AnyResult<M> {
         match self.current {
             JsonElement::Stack(JsonStackElement::Object(stack_obj)) => {
                 let new_stack_obj = JsonStackObject {
@@ -519,151 +555,7 @@ impl<D: Dealloc> AnyState<D> {
         }
     }
 
-    pub fn begin_array(mut self) -> AnyResult<D> {
-        let new_top = JsonStackElement::Array(Vec::default());
-        if let JsonElement::Stack(top) = self.current {
-            self.stack.push(top);
-        }
-        AnyResult::Continue(AnyState {
-            status: ParsingStatus::ArrayBegin,
-            current: JsonElement::Stack(new_top),
-            ..self
-        })
-    }
-
-    pub fn begin_object(mut self) -> AnyResult<D> {
-        let new_top: JsonStackElement<D> = JsonStackElement::Object(JsonStackObject {
-            map: BTreeMap::default(),
-            key: String::default(),
-        });
-        if let JsonElement::Stack(top) = self.current {
-            self.stack.push(top)
-        }
-        AnyResult::Continue(AnyState {
-            status: ParsingStatus::ObjectBegin,
-            current: JsonElement::Stack(new_top),
-            ..self
-        })
-    }
-
-    pub fn parse_object_key(self, token: JsonToken) -> AnyResult<D> {
-        match token {
-            JsonToken::Colon => AnyResult::Continue(AnyState {
-                status: ParsingStatus::ObjectColon,
-                ..self
-            }),
-            _ => AnyResult::Error(ParseError::UnexpectedToken),
-        }
-    }
-}
-
-/// AnyStateExtension contains AnyState methods that use Manager (not only Dealloc).
-pub trait AnyStateExtension<M: Manager> {
-    fn end_array(self, manager: M) -> AnyResult<M::Dealloc>;
-    fn end_object(self, manager: M) -> AnyResult<M::Dealloc>;
-    fn parse(self, manager: M, token: JsonToken) -> AnyResult<M::Dealloc>;
-    fn parse_for_module(
-        self,
-        manager: M,
-        token: JsonToken,
-        _module_cache_progress: &mut BTreeSet<String>,
-    ) -> JsonState<M::Dealloc>;
-    fn parse_value(self, manager: M, token: JsonToken) -> AnyResult<M::Dealloc>;
-    fn parse_array_comma(self, manager: M, token: JsonToken) -> AnyResult<M::Dealloc>;
-    fn parse_array_begin(self, manager: M, token: JsonToken) -> AnyResult<M::Dealloc>;
-    fn parse_array_value(self, manager: M, token: JsonToken) -> AnyResult<M::Dealloc>;
-    fn parse_object_begin(self, manager: M, token: JsonToken) -> AnyResult<M::Dealloc>;
-    fn parse_object_next(self, manager: M, token: JsonToken) -> AnyResult<M::Dealloc>;
-    fn parse_object_comma(self, manager: M, token: JsonToken) -> AnyResult<M::Dealloc>;
-}
-
-impl<M: Manager> AnyStateExtension<M> for AnyState<M::Dealloc> {
-    fn end_array(mut self, manager: M) -> AnyResult<M::Dealloc> {
-        match self.current {
-            JsonElement::Stack(JsonStackElement::Array(array)) => {
-                let js_array = new_array(manager, array).to_ref();
-                let current = match self.stack.pop() {
-                    Some(element) => JsonElement::Stack(element),
-                    None => JsonElement::None,
-                };
-                let new_state = AnyState { current, ..self };
-                new_state.push_value(Any::move_from(js_array))
-            }
-            _ => unreachable!(),
-        }
-    }
-
-    fn end_object(mut self, manager: M) -> AnyResult<M::Dealloc> {
-        match self.current {
-            JsonElement::Stack(JsonStackElement::Object(object)) => {
-                let vec = object
-                    .map
-                    .into_iter()
-                    .map(|kv| (to_js_string(manager, kv.0), kv.1))
-                    .collect::<Vec<_>>();
-                let js_object = new_object(manager, vec).to_ref();
-                let current = match self.stack.pop() {
-                    Some(element) => JsonElement::Stack(element),
-                    None => JsonElement::None,
-                };
-                let new_state = AnyState { current, ..self };
-                new_state.push_value(Any::move_from(js_object))
-            }
-            _ => unreachable!(),
-        }
-    }
-
-    fn parse(self, manager: M, token: JsonToken) -> AnyResult<M::Dealloc> {
-        match self.status {
-            ParsingStatus::Initial | ParsingStatus::ObjectColon => self.parse_value(manager, token),
-            ParsingStatus::ArrayBegin => self.parse_array_begin(manager, token),
-            ParsingStatus::ArrayValue => self.parse_array_value(manager, token),
-            ParsingStatus::ArrayComma => self.parse_array_comma(manager, token),
-            ParsingStatus::ObjectBegin => self.parse_object_begin(manager, token),
-            ParsingStatus::ObjectKey => self.parse_object_key(token),
-            ParsingStatus::ObjectValue => self.parse_object_next(manager, token),
-            ParsingStatus::ObjectComma => self.parse_object_comma(manager, token),
-            ParsingStatus::ImportBegin => self.parse_import_begin(token),
-            ParsingStatus::ImportValue => todo!(), // any_state, context, token),
-            ParsingStatus::ImportEnd => self.parse_import_end(token),
-        }
-    }
-
-    fn parse_for_module(
-        self,
-        manager: M,
-        token: JsonToken,
-        _module_cache_progress: &mut BTreeSet<String>,
-    ) -> JsonState<M::Dealloc> {
-        let result = self.parse(manager, token);
-        match result {
-            AnyResult::Continue(state) => JsonState::ParseModule(state),
-            AnyResult::Success(success) => JsonState::Result(ParseResult {
-                data_type: success.state.data_type,
-                any: success.value,
-            }),
-            AnyResult::Error(error) => JsonState::Error(error),
-        }
-    }
-
-    fn parse_value(self, manager: M, token: JsonToken) -> AnyResult<M::Dealloc> {
-        match token {
-            JsonToken::ArrayBegin => self.begin_array(),
-            JsonToken::ObjectBegin => self.begin_object(),
-            JsonToken::Id(s) if self.data_type.is_cjs_compatible() && s == "require" => {
-                self.begin_import()
-            }
-            _ => {
-                let option_any = token.try_to_any(manager, &self.consts);
-                match option_any {
-                    Some(any) => self.push_value(any),
-                    None => AnyResult::Error(ParseError::UnexpectedToken),
-                }
-            }
-        }
-    }
-
-    fn parse_array_comma(self, manager: M, token: JsonToken) -> AnyResult<M::Dealloc> {
+    pub fn parse_array_comma(self, manager: M, token: JsonToken) -> AnyResult<M> {
         match token {
             JsonToken::ArrayBegin => self.begin_array(),
             JsonToken::ObjectBegin => self.begin_object(),
@@ -681,7 +573,7 @@ impl<M: Manager> AnyStateExtension<M> for AnyState<M::Dealloc> {
         }
     }
 
-    fn parse_array_begin(self, manager: M, token: JsonToken) -> AnyResult<M::Dealloc> {
+    pub fn parse_array_begin(self, manager: M, token: JsonToken) -> AnyResult<M> {
         match token {
             JsonToken::ArrayBegin => self.begin_array(),
             JsonToken::ArrayEnd => self.end_array(manager),
@@ -696,7 +588,7 @@ impl<M: Manager> AnyStateExtension<M> for AnyState<M::Dealloc> {
         }
     }
 
-    fn parse_array_value(self, manager: M, token: JsonToken) -> AnyResult<M::Dealloc> {
+    pub fn parse_array_value(self, manager: M, token: JsonToken) -> AnyResult<M> {
         match token {
             JsonToken::ArrayEnd => self.end_array(manager),
             JsonToken::Comma => AnyResult::Continue(AnyState {
@@ -707,7 +599,34 @@ impl<M: Manager> AnyStateExtension<M> for AnyState<M::Dealloc> {
         }
     }
 
-    fn parse_object_begin(self, manager: M, token: JsonToken) -> AnyResult<M::Dealloc> {
+    pub fn begin_array(mut self) -> AnyResult<M> {
+        let new_top = JsonStackElement::Array(Vec::default());
+        if let JsonElement::Stack(top) = self.current {
+            self.stack.push(top);
+        }
+        AnyResult::Continue(AnyState {
+            status: ParsingStatus::ArrayBegin,
+            current: JsonElement::Stack(new_top),
+            ..self
+        })
+    }
+
+    pub fn end_array(mut self, manager: M) -> AnyResult<M> {
+        match self.current {
+            JsonElement::Stack(JsonStackElement::Array(array)) => {
+                let js_array = new_array(manager, array).to_ref();
+                let current = match self.stack.pop() {
+                    Some(element) => JsonElement::Stack(element),
+                    None => JsonElement::None,
+                };
+                let new_state = AnyState { current, ..self };
+                new_state.push_value(Any::move_from(js_array))
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn parse_object_begin(self, manager: M, token: JsonToken) -> AnyResult<M> {
         match token {
             JsonToken::String(s) => self.push_key(s),
             JsonToken::Id(s) if self.data_type.is_djs() => self.push_key(s),
@@ -716,7 +635,7 @@ impl<M: Manager> AnyStateExtension<M> for AnyState<M::Dealloc> {
         }
     }
 
-    fn parse_object_next(self, manager: M, token: JsonToken) -> AnyResult<M::Dealloc> {
+    pub fn parse_object_next(self, manager: M, token: JsonToken) -> AnyResult<M> {
         match token {
             JsonToken::ObjectEnd => self.end_object(manager),
             JsonToken::Comma => AnyResult::Continue(AnyState {
@@ -727,11 +646,56 @@ impl<M: Manager> AnyStateExtension<M> for AnyState<M::Dealloc> {
         }
     }
 
-    fn parse_object_comma(self, manager: M, token: JsonToken) -> AnyResult<M::Dealloc> {
+    pub fn parse_object_comma(self, manager: M, token: JsonToken) -> AnyResult<M> {
         match token {
             JsonToken::String(s) => self.push_key(s),
             JsonToken::ObjectEnd => self.end_object(manager),
             _ => AnyResult::Error(ParseError::UnexpectedToken),
+        }
+    }
+
+    pub fn parse_object_key(self, token: JsonToken) -> AnyResult<M> {
+        match token {
+            JsonToken::Colon => AnyResult::Continue(AnyState {
+                status: ParsingStatus::ObjectColon,
+                ..self
+            }),
+            _ => AnyResult::Error(ParseError::UnexpectedToken),
+        }
+    }
+
+    pub fn begin_object(mut self) -> AnyResult<M> {
+        let new_top: JsonStackElement<M::Dealloc> = JsonStackElement::Object(JsonStackObject {
+            map: BTreeMap::default(),
+            key: String::default(),
+        });
+        if let JsonElement::Stack(top) = self.current {
+            self.stack.push(top)
+        }
+        AnyResult::Continue(AnyState {
+            status: ParsingStatus::ObjectBegin,
+            current: JsonElement::Stack(new_top),
+            ..self
+        })
+    }
+
+    pub fn end_object(mut self, manager: M) -> AnyResult<M> {
+        match self.current {
+            JsonElement::Stack(JsonStackElement::Object(object)) => {
+                let vec = object
+                    .map
+                    .into_iter()
+                    .map(|kv| (to_js_string(manager, kv.0), kv.1))
+                    .collect::<Vec<_>>();
+                let js_object = new_object(manager, vec).to_ref();
+                let current = match self.stack.pop() {
+                    Some(element) => JsonElement::Stack(element),
+                    None => JsonElement::None,
+                };
+                let new_state = AnyState { current, ..self };
+                new_state.push_value(Any::move_from(js_object))
+            }
+            _ => unreachable!(),
         }
     }
 }


### PR DESCRIPTION
The near goal of this refactoring is to move more of parser.rs logic to shared.rs - to reuse that logic in analyzer.rs.

The difference between parser.rs and shared.rs variants is this: there are no dependencies on Io in shared.rs.

The first iteration of this PR is a midway checkpoint, it will not be merged in this state - I am publishing for discussion purposes.